### PR TITLE
Makefile ONESHELL Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .ONESHELL:
+.SHELLFLAGS := -ec
+SHELL := /bin/bash
 .PHONY: lint fmt build dev_cert test test_unit test_integration
 
 lint:


### PR DESCRIPTION
The shell for make should have "-e" to stop on errors.