### PR TITLE
Added payload tests for api keys and cloud accounts

### DIFF
--- a/api/payloads/api_key_test.go
+++ b/api/payloads/api_key_test.go
@@ -1,0 +1,17 @@
+package payloads
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAPIKeyPayload_Bind(t *testing.T) {
+	payload := CreateAPIKeyPayload{
+		Data: CreateAPIKeyPayloadData{
+			Owner:       "test",
+			Description: "test",
+		}}
+	err := payload.Bind(nil)
+	assert.Nil(t, err)
+}

--- a/api/payloads/cloud_accounts.go
+++ b/api/payloads/cloud_accounts.go
@@ -4,45 +4,8 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgtype"
 	"github.com/pkg/errors"
 )
-
-//----------------------------------------------------------------------------------------------------------------------
-// Update Cloud Accounts
-//----------------------------------------------------------------------------------------------------------------------
-
-// UpdateCloudAccountPayloadData is the data for the UpdateCloudAccountPayload.
-type UpdateCloudAccountPayloadData struct {
-	TagsDesired map[string]string `json:"tags_desired"`
-	json        pgtype.JSONB
-}
-
-// UpdateCloudAccountPayload is the payload for updating a cloud account.
-type UpdateCloudAccountPayload struct {
-	Data UpdateCloudAccountPayloadData `json:"data"`
-}
-
-// Bind binds extra data from the payload UpdateCloudAccountPayload.
-func (u *UpdateCloudAccountPayload) Bind(_ *http.Request) error {
-	if u.Data.TagsDesired == nil {
-		return errors.Errorf("tags_desired is required")
-	}
-
-	jsonTags := pgtype.JSONB{}
-	err := jsonTags.Set(u.Data.TagsDesired)
-	if err != nil {
-		return err
-	}
-	u.Data.json = jsonTags
-
-	return nil
-}
-
-// GetJSON returns the parsed JSONB for the tags.
-func (u *UpdateCloudAccountPayloadData) GetJSON() pgtype.JSONB {
-	return u.json
-}
 
 //----------------------------------------------------------------------------------------------------------------------
 // Assign Cloud Accounts to Organizational Units

--- a/api/payloads/cloud_accounts_test.go
+++ b/api/payloads/cloud_accounts_test.go
@@ -1,0 +1,50 @@
+package payloads
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssignCloudAccountToOUPayload_Bind(t *testing.T) {
+	tc := []struct {
+		name        string
+		ouID        string
+		expectError bool
+	}{
+		{
+			name:        "valid ou id",
+			ouID:        uuid.New().String(),
+			expectError: false,
+		},
+		{
+			name:        "invalid ou id",
+			ouID:        "foobar",
+			expectError: true,
+		},
+		{
+			name:        "empty ou id",
+			ouID:        "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := AssignCloudAccountToOUPayload{
+				Data: AssignCloudAccountToOUPayloadData{
+					OrganizationalUnitID: tt.ouID,
+				}}
+			err := payload.Bind(nil)
+			if tt.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			if err == nil && tt.ouID != "" {
+				assert.Equal(t, tt.ouID, payload.Data.GetOrganizationalUnitID().String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Note: Update cloud account payload was no longer used, so it was removed.